### PR TITLE
Parse actual TSV in parse_bins

### DIFF
--- a/files/clusters.tsv
+++ b/files/clusters.tsv
@@ -1,3 +1,4 @@
+clustername	contigname
 C1	s1
 C1	s2
 C2	s3

--- a/src/reference.jl
+++ b/src/reference.jl
@@ -242,11 +242,15 @@ function parse_bins(
     ref::Reference,
     binsplit_sep::Union{Nothing, AbstractString, Char}=nothing,
 )::Dict{<:AbstractString, Vector{Sequence}}
-    itr = tab_pairs(eachline(io))
-    if binsplit_sep !== nothing
-        itr = binsplit_tab_pairs(itr, binsplit_sep)
+    lines = eachline(io)
+    header = "clustername\tcontigname"
+    it = iterate(lines)
+    if (isnothing(it) ? nothing : rstrip(first(it))) != header
+        error(lazy"Expected following header line in cluster file: $(repr(header))")
     end
-    seqs_by_binname = Dict{SubString{String}, Vector{Sequence}}()
+    itr = tab_pairs(lines)
+    itr = isnothing(binsplit_sep) ? itr : binsplit_tab_pairs(itr, binsplit_sep)
+    seqs_by_binname = Dict{String, Vector{Sequence}}()
     for (binname, seqname) in itr
         (seq, _) = ref.targets_by_name[seqname]
         push!(get!(valtype(seqs_by_binname), seqs_by_binname, binname), seq)


### PR DESCRIPTION
Previously, Vamb didn't output the TSV file in actual TSV format, forgetting the header. Update the parser here so it requires the header to be present.