### PR TITLE
Add passes_* functions to filter bins

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "BinBencherBackend"
 uuid = "63a9268e-b9e5-4a07-aba6-1f52d4878f75"
 authors = ["Jakob Nybo Nissen <jakobnybonissen@gmail.com>"]
-version = "0.2.0"
+version = "0.2.1"
 
 [deps]
 AbstractTrees = "1520ce14-60c1-5f80-bbc7-55ef81b5835c"

--- a/src/BinBencherBackend.jl
+++ b/src/BinBencherBackend.jl
@@ -67,6 +67,8 @@ export Sequence,
     subset,
     subset!,
     f1,
+    passes_f1,
+    passes_recall_precision,
     fscore,
     mrca,
     print_matrix


### PR DESCRIPTION
The functions `passes_f1` and `passes_recall_precision` can be used to filter away bins that fall below some threshold of recall/precisions for any Genome.