### PR TITLE
Convert seqs to indices temporarily when parsing

### DIFF
--- a/src/BinBencherBackend.jl
+++ b/src/BinBencherBackend.jl
@@ -13,8 +13,8 @@ include("sequence.jl")
 include("source.jl")
 include("clade.jl")
 include("genome.jl")
-include("bin.jl")
 include("reference.jl")
+include("bin.jl")
 include("binning.jl")
 
 vector(x)::Vector = x isa Vector ? x : vec(collect(x))::Vector

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -60,7 +60,8 @@ end
 
 function test_is_same_reference(a::Reference, b::Reference)
     @test genomes(a) == genomes(b)
-    @test a.targets_by_name == b.targets_by_name
+    @test a.targets == b.targets
+    @test a.target_index_by_name == b.target_index_by_name
     @test nseqs(a) == nseqs(b)
     @test [[c.name for c in v] for v in a.clades] == [[c.name for c in v] for v in b.clades]
 end


### PR DESCRIPTION
Instead of parsing the binning file to sequences, instead parse them into integer indices. This simplifies a bunch of operations on the sequences. Before instantiating the Bins, the indices are converted to Sequence objects.