### PR TITLE
Include BinStats object in Binning

### DIFF
--- a/docs/src/walkthrough.md
+++ b/docs/src/walkthrough.md
@@ -182,6 +182,8 @@ Binning
     Assembled:  91.3 %
   Bins:        6
   NC genomes:  0
+  Mean bin genome   R/P/F1: 0.62 / 0.929 / 0.701
+  Mean bin assembly R/P/F1: 0.653 / 0.932 / 0.733
   Precisions: [0.6, 0.7, 0.8, 0.9, 0.95, 0.99]
   Recalls:    [0.6, 0.7, 0.8, 0.9, 0.95, 0.99]
   Reconstruction (assemblies):

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -208,6 +208,11 @@ end
 
     bins2 = Binning(CLUSTERS_PATH, ref)
     test_is_same_binning(bins, bins2)
+
+    @test bins.bin_genome_stats.mean_bin_recall ≈ 0.5796363636363636
+    @test bins.bin_genome_stats.mean_bin_precision ≈ 0.9435897435897436
+    @test bins.bin_asm_stats.mean_bin_recall ≈ 0.7224489795918367
+    @test bins.bin_asm_stats.mean_bin_precision ≈ 0.9454545454545455
 end
 
 @testset "Gold standard" begin


### PR DESCRIPTION
Now compute mean recall / precision / F1 for bins automatically. In a later version, computing this might be an optional second step, such that it can be skipped when not needed.
I'd also like to compute the adjusted Rand index, but this is quite a bit more complex.