### PR TITLE
Bugfix: Compute max F1 correctly

### DIFF
--- a/docs/make.jl
+++ b/docs/make.jl
@@ -27,6 +27,7 @@ makedocs(;
         "Reference" => "reference.md",
     ],
     checkdocs=:all,
+    # doctest = :fix,
 )
 
 deploydocs(; repo="github.com/jakobnissen/BinBencherBackend.jl.git", push_preview=true)

--- a/docs/src/walkthrough.md
+++ b/docs/src/walkthrough.md
@@ -182,8 +182,8 @@ Binning
     Assembled:  91.3 %
   Bins:        6
   NC genomes:  0
-  Mean bin genome   R/P/F1: 0.62 / 0.929 / 0.701
-  Mean bin assembly R/P/F1: 0.653 / 0.932 / 0.733
+  Mean bin genome   R/P/F1: 0.51 / 1.0 / 0.672
+  Mean bin assembly R/P/F1: 0.546 / 1.0 / 0.704
   Precisions: [0.6, 0.7, 0.8, 0.9, 0.95, 0.99]
   Recalls:    [0.6, 0.7, 0.8, 0.9, 0.95, 0.99]
   Reconstruction (assemblies):

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -11,6 +11,11 @@ CLUSTERS_STR = read(CLUSTERS_PATH, String)
 @assert isdir(DIR)
 ngenomes(ref) = length(genomes(ref))
 
+@testset "Misc" begin
+    @test isnan(f1(0.0, 0.0))
+    @test !isnan(f1(1e-6, 1e-6))
+end
+
 @testset "Flags" begin
     empt = FlagSet()
     a = FlagSet([Flags.organism, Flags.plasmid])
@@ -209,10 +214,10 @@ end
     bins2 = Binning(CLUSTERS_PATH, ref)
     test_is_same_binning(bins, bins2)
 
-    @test bins.bin_genome_stats.mean_bin_recall ≈ 0.5796363636363636
-    @test bins.bin_genome_stats.mean_bin_precision ≈ 0.9435897435897436
-    @test bins.bin_asm_stats.mean_bin_recall ≈ 0.7224489795918367
-    @test bins.bin_asm_stats.mean_bin_precision ≈ 0.9454545454545455
+    @test bins.bin_genome_stats.mean_bin_recall ≈ 0.4916363636363636
+    @test bins.bin_genome_stats.mean_bin_precision ≈ 1
+    @test bins.bin_asm_stats.mean_bin_recall ≈ 0.636734693877551
+    @test bins.bin_asm_stats.mean_bin_precision ≈ 1
 end
 
 @testset "Gold standard" begin


### PR DESCRIPTION
* Fix mistake in recall_prec_max_f1 and simplify function
* fscore now returns NaN when rec == prec == 0.0