### PR TITLE
Bugfix: Filter genome on Bin construction

### DIFF
--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -206,10 +206,16 @@ end
     # Test filter_genomes works
     empty_binning = Binning(IOBuffer(CLUSTERS_STR), ref; filter_genomes=Returns(false))
     @test n_recovered(empty_binning, 0.1, 0.1) == 0
+    @test all(m -> all(iszero, m), empty_binning.recovered_asms)
+    @test all(m -> all(iszero, m), empty_binning.recovered_genomes)
 
     only_virus = Binning(IOBuffer(CLUSTERS_STR), ref; filter_genomes=is_virus)
     @test BinBencherBackend.n_nc(only_virus) == 0
     @test n_recovered(only_virus, 0.1, 0.1; assembly=true) == 1
+
+    # This test depends on the exact state of the ref and binning used
+    @test all(m -> all(isone, m), only_virus.recovered_asms)
+    @test all(m -> all(iszero, m), only_virus.recovered_genomes)
 
     bins2 = Binning(CLUSTERS_PATH, ref)
     test_is_same_binning(bins, bins2)


### PR DESCRIPTION
The precision/recall values between Genome/Bin and Clade/Bin pairs are computed when the Bin objects are instantiated shortly after parsing the clusters, but before calling the `benchmark` function, whose job it is to compute the summary statistics stored in the Binning object itself.

Before this commit, passing `filter_genomes` to a Binning would instantiate the Bins without filtering, and then filter them when computing the summary stats. This was done by simply skipping the removed genomes during the computation of summary statistics.
However, the filtering of genomes did not affect statistics for Clades, because clades could not simply be skipped (since only _some_ of their genomes might be removed). This resulted in wrong (unfiltered) clade statistics.

In this commit, filter the genomes already when the Bins are constructed.