### PR TITLE
Store total depth per genome in Bin object

### DIFF
--- a/src/binning.jl
+++ b/src/binning.jl
@@ -412,7 +412,7 @@ function benchmark(
             (zeros(Float64, length(precisions)), zeros(Float64, length(precisions)))
     end
     for bin in bins
-        for (genome, (asmsize, foreign)) in bin.genomes
+        for (genome, (; asmsize, foreign)) in bin.genomes
             (v_asm, v_genome) = max_genome_recall_at_precision[genome]
             precision = asmsize / (asmsize + foreign)
             asm_recall = asmsize / genome.assembly_size

--- a/src/reference.jl
+++ b/src/reference.jl
@@ -226,6 +226,7 @@ function uninit!(ref::Reference)
         @uninit! genome.assembly_size
         for source in genome.sources
             @uninit! source.assembly_size
+            @uninit! source.total_bp
         end
     end
     ref


### PR DESCRIPTION
This is not used for now, but this will allow BBB to present summary statistics such as the number of redundant basepairs, depth of recovered genomes, and more.