### PR TITLE
Consistently forbid some characters in names

### DIFF
--- a/src/bin.jl
+++ b/src/bin.jl
@@ -62,6 +62,7 @@ function Bin(
     sequences, # iterator of Sequence
     considered_genomes::Union{Nothing, Set{Genome}}=nothing,
 )
+    name = check_valid_identifier(String(name))
     indices = [ref.target_index_by_name[s.name] for s in sequences]
     scratch = Vector{Tuple{Int, Int}}()
     bin_by_indices(name, indices, ref.targets, scratch, considered_genomes)

--- a/src/clade.jl
+++ b/src/clade.jl
@@ -35,6 +35,7 @@ mutable struct Clade{G}
     parent::Union{Clade{G}, Nothing}
 
     function Clade(name::String, child::Union{Clade{G}, G}) where {G}
+        check_valid_identifier(name)
         (rank, ngenomes) = if child isa G
             (@isinit(child.parent)) &&
                 existing_parent_error(name, child.name, child.parent.name)

--- a/src/genome.jl
+++ b/src/genome.jl
@@ -7,7 +7,14 @@
     @lazy assembly_size::Int
 
     function Genome(name::AbstractString, flags::FlagSet)
-        new(String(name), Set{Source{Genome}}(), flags, uninit, uninit, uninit)
+        new(
+            check_valid_identifier(String(name)),
+            Set{Source{Genome}}(),
+            flags,
+            uninit,
+            uninit,
+            uninit,
+        )
     end
 end
 Genome(name::AbstractString) = Genome(name, FlagSet())

--- a/src/sequence.jl
+++ b/src/sequence.jl
@@ -21,12 +21,7 @@ struct Sequence
     length::Int
 
     function Sequence(name::AbstractString, length::Integer)
-        str = String(name)
-        if isempty(str) || isspace(first(str)) || isspace(last(str))
-            error(
-                lazy"Sequence name \"$(str)\" cannot be empty or have leading or trailing whitespace",
-            )
-        end
+        str = check_valid_identifier(String(name))
         length < 1 && throw(ArgumentError("Cannot instantiate an empty sequence"))
         new(str, Int(length))
     end

--- a/src/source.jl
+++ b/src/source.jl
@@ -9,7 +9,7 @@
     function Source(genome::G, name::AbstractString, length::Integer) where {G}
         length ≤ 0 && error("Source length must be at least 1")
         new{G}(
-            String(name),
+            check_valid_identifier(String(name)),
             genome,
             Int(length),
             Vector{Tuple{Sequence, Tuple{Int, Int}}}(),

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -118,9 +118,15 @@ end
     @test_throws Exception Sequence("abc", -5)
 
     # Bad names
-    @test_throws Exception Sequence("", 5)
-    @test_throws Exception Sequence(" abc", 5)
-    @test_throws Exception Sequence("abc ", 5)
+    @test_throws Exception Sequence("a\tb", 5)
+    @test_throws Exception Sequence("a\rbc", 5)
+    @test_throws Exception Sequence("\n\n", 5)
+
+    # Ok names
+    @test Sequence("", 1) isa Sequence
+    @test Sequence("   ", 1) isa Sequence
+    @test Sequence("\0\v\f", 1) isa Sequence
+    @test Sequence("\xff\xff", 1) isa Sequence
 
     @test map(length, seqs) == [5, 6, 7]
     @test s1 == s3 # we might change this behaviour
@@ -135,6 +141,13 @@ end
     @test is_virus(gens[3])
     @test !is_organism(gens[3])
     @test !is_virus(gens[1])
+
+    for good_name in ["", "  ", "\xff\0\0"]
+        @test Genome(good_name) isa Genome
+    end
+    for bad_name in ["\r\n", "abc\na", "a\ta"]
+        @test_throws Exception Genome(bad_name)
+    end
 end
 
 @testset "Clade" begin


### PR DESCRIPTION
Do not allow tab, newline and carriage return in names, since these will mess up the parsers.
This is intentionally a very loose criteria. It's alright if the names contain null bytes or otherwise arbitrary bytes, since this should not break the parsers