### PR TITLE
Allow constructing a Binning from explicit Bins

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "BinBencherBackend"
 uuid = "63a9268e-b9e5-4a07-aba6-1f52d4878f75"
 authors = ["Jakob Nybo Nissen <jakobnybonissen@gmail.com>"]
-version = "0.3.0"
+version = "0.3.1"
 
 [deps]
 AbstractTrees = "1520ce14-60c1-5f80-bbc7-55ef81b5835c"

--- a/docs/src/nomenclariture.md
+++ b/docs/src/nomenclariture.md
@@ -17,8 +17,8 @@
   All genomes descend from a chain of exactly N ranks of clades, where N > 0.
 * A __bin__ is a set of sequences created by the binner. Every bin is benchmarked against all genomes and clades in the reference.
 * A __reference__ is composed of:
-    - The set of genomes__ to benchmark against,
-      which all ultimately descend from a single common clades that links all genomes together.
+    - The set of genomes to benchmark against,
+      which all ultimately descend from a single common clade.
     - Its set of sequences each with zero or more mappings to its genomes' sources.
 * A __binning__ is a set of bins benchmarked against a reference, where every bin is a subset of the reference's sequences.
 

--- a/src/bin.jl
+++ b/src/bin.jl
@@ -1,6 +1,35 @@
 """
-    Bin(name::AbstractString, ref::Reference, sequences)
+    Bin(
+        name::AbstractString,
+        ref::Reference,
+        sequences,
+        considered_genomes::Union{Set{Genome}, Nothing}=nothing
+    )
 
+Construct a bin from an iterable of `Sequence` from a `Reference`.
+
+If `considered_genomes` is not `nothing`, then any genomes not in the set will be ignored
+and so sequences mapping to those genomes will not count as contamination, and nor will
+the bin contain information about sequences mapping to those genomes.
+
+# Examples
+```jldoctest
+julia> bin = first(binning.bins)
+Bin "C1"
+  Sequences: 2
+  Breadth:   65
+  Intersecting 1 genome
+
+julia> first(bin.sequences)
+Sequence("s1", 25)
+
+julia> f1(first(ref.genomes), bin)
+0.5714285714285715
+```
+
+See also: [`Binning`](@ref), [`Genome`](@ref), [`Clade`](@ref)
+
+# Extended help
 `Bin`s each represent a bin created by the binner. Conceptually, they are simply
 a set of `Sequence` with a name attached.
 Practically, every `Bin` is benchmarked against all `Genome`s and `Clade`s of a given `Reference`,
@@ -19,23 +48,6 @@ or _genomes_ as the ground truth.
 For `Bin`/`Clade` pairs B/C, recall is the maximal recall of B/Ch for all children Ch of C.
 Precision is the sum of lengths of sequences mapping to any child of the clade divided
 by the sum of lengths of all sequences in the bin.
-
-See also: [`Binning`](@ref), [`Genome`](@ref), [`Clade`](@ref)
-
-# Examples
-```jldoctest
-julia> bin = first(binning.bins)
-Bin "C1"
-  Sequences: 2
-  Breadth:   65
-  Intersecting 1 genome
-
-julia> first(bin.sequences)
-Sequence("s1", 25)
-
-julia> f1(first(ref.genomes), bin)
-0.5714285714285715
-```
 """
 struct Bin
     name::String


### PR DESCRIPTION
Document and test another method of Binning, which creates a Binning from a vec of Bin. This allows users to manually construct their bins instead of having to load them from a file.

Similar, add a new `filter_bins` kwarg to Binning, which removes any bin not passing the predicate.