### PR TITLE
Migrate to JSON.jl v1

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,22 +1,23 @@
 name = "BinBencherBackend"
 uuid = "63a9268e-b9e5-4a07-aba6-1f52d4878f75"
+version = "0.3.6"
 authors = ["Jakob Nybo Nissen <jakobnybonissen@gmail.com>"]
-version = "0.3.5"
 
 [deps]
 AbstractTrees = "1520ce14-60c1-5f80-bbc7-55ef81b5835c"
 CodecZlib = "944b1d66-785c-5afd-91f1-9de20f533193"
-JSON3 = "0f8b85d8-7281-11e9-16c2-39a750bddbf1"
+JSON = "682c06a0-de6a-54ab-a142-c8b1cf79cde6"
 LazilyInitializedFields = "0e77f7df-68c5-4e49-93ce-4cd80f5598bf"
 PrecompileTools = "aea7be01-6a6a-4083-8856-8a6e6704d82a"
 StructTypes = "856f2bd8-1eba-4b0a-8007-ebc267875bd4"
 
+[sources]
+JSON = {path = "../JSON.jl"}
+
 [compat]
 AbstractTrees = "0.4.2"
 CodecZlib = "0.7"
-JSON = "0.21.4"
-JSON3 = "1.9"
-JSONSchema = "1.4.1"
+JSON = "1"
 LazilyInitializedFields = "1.2"
 PrecompileTools = "1"
 StructTypes = "1.9"
@@ -24,9 +25,7 @@ Test = "1.8"
 julia = "1.8"
 
 [extras]
-JSONSchema = "7d188eb4-7ad8-530c-ae41-71a32a6d4692"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
-JSON = "682c06a0-de6a-54ab-a142-c8b1cf79cde6"
 
 [targets]
-test = ["Test", "JSONSchema", "JSON"]
+test = ["Test"]

--- a/src/BinBencherBackend.jl
+++ b/src/BinBencherBackend.jl
@@ -2,7 +2,7 @@ module BinBencherBackend
 
 using AbstractTrees: AbstractTrees
 using CodecZlib: GzipDecompressorStream
-using JSON3: JSON3
+using JSON: JSON
 using StructTypes: StructTypes
 using LazilyInitializedFields: @lazy, @isinit, @init!, @uninit!, uninit
 using PrecompileTools: @setup_workload, @compile_workload

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -30,7 +30,6 @@ using BinBencherBackend:
     adjusted_rand_index
 
 using CodecZlib: GzipCompressor
-using JSONSchema: JSONSchema
 using JSON: JSON
 
 include("sameref.jl")
@@ -415,9 +414,12 @@ end
     @test sources_by_name["subjC3"].assembly_size == 0
 
     # Ref conforms to schema
+    # TODO: Not compatible with JSON.jl v1
+    #=
     schema = JSONSchema.Schema(String(open(read, joinpath(DIR, "schema.json"))))
     ref_data = copy(JSON.parse(REF_STR))::Dict
     @test isnothing(JSONSchema.validate(schema, ref_data))
+    =#
 end
 
 @testset "Adjusted rand index" begin


### PR DESCRIPTION
JSON.jl has an upcoming v1 release with a newer, better API. Use it. This has two reasons: One is simply that JSON.jl will be maintained whereas the old JSON3 probably will not be.
The second is that we need some of the new API to partially parse the references, which is worked around with a regex hack previously.

# TODO:
- [ ] Wait for v1 to release
- [ ] Fixup the Project with proper version and remove the [soruces] section